### PR TITLE
fix: Backend CI - web3j transitive dep exclusions + test context isolation

### DIFF
--- a/travelmate-backend/pom.xml
+++ b/travelmate-backend/pom.xml
@@ -141,6 +141,16 @@
             <groupId>org.web3j</groupId>
             <artifactId>core</artifactId>
             <version>4.10.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- IPFS for NFT Metadata Storage -->

--- a/travelmate-backend/src/test/java/com/travelmate/controller/UserControllerTest.java
+++ b/travelmate-backend/src/test/java/com/travelmate/controller/UserControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -32,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
                 classes = {JwtAuthenticationFilter.class}))
 @org.springframework.context.annotation.Import(com.travelmate.config.TestSecurityConfig.class)
+@ActiveProfiles("test")
 @DisplayName("사용자 컨트롤러 테스트")
 class UserControllerTest {
 

--- a/travelmate-backend/src/test/resources/application.yml
+++ b/travelmate-backend/src/test/resources/application.yml
@@ -1,0 +1,38 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration
+      - org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: false
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+app:
+  jwt:
+    secret: testSecretKey123456789012345678901234567890
+    expiration: 3600000
+    refresh-expiration: 604800000
+  mail:
+    enabled: false
+  redis:
+    enabled: false
+
+logging:
+  level:
+    com.travelmate: WARN
+    org.springframework: WARN
+    org.hibernate: WARN


### PR DESCRIPTION
## 문제
- `IllegalStateException: ApplicationContext failure threshold (1) exceeded`
- web3j 4.10.3 ↔ Spring Boot 3.4.0 transitive dependency 충돌 (netty, okhttp3)

## 변경사항

### pom.xml
- web3j `core` 4.10.3에 `io.netty:*`, `com.squareup.okhttp3:*` exclusions 추가
- Spring Boot BOM이 관리하는 버전 우선 적용

### src/test/resources/application.yml (신규)
- Elasticsearch / Redis AutoConfiguration 테스트 컨텍스트에서 제외
- H2 인메모리 DB (MODE=PostgreSQL) 사용

### UserControllerTest.java
- `@ActiveProfiles("test")` 추가 → test 프로파일 명시 활성화

## 관련
PR #68 Backend CI 차단 이슈 해결
