### PR TITLE
fix: resolve backend compilation and frontend test failures

### DIFF
--- a/travelmate-backend/pom.xml
+++ b/travelmate-backend/pom.xml
@@ -146,10 +146,6 @@
                     <groupId>io.netty</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 

--- a/travelmate-web/src/locales/en/auth.json
+++ b/travelmate-web/src/locales/en/auth.json
@@ -10,7 +10,7 @@
     "noAccount": "Don't have an account?",
     "signupLink": "Sign up",
     "or": "or",
-    "continueWith": "Continue with {{provider}}",
+    "continueWith": "Continue with {provider}",
     "google": "Google",
     "kakao": "Kakao",
     "naver": "Naver"

--- a/travelmate-web/src/locales/en/chat.json
+++ b/travelmate-web/src/locales/en/chat.json
@@ -11,8 +11,8 @@
     "sent": "Sent",
     "delivered": "Delivered",
     "read": "Read",
-    "typing": "{{name}} is typing...",
-    "typingMultiple": "{{name}} and {{count}} others are typing...",
+    "typing": "{name} is typing...",
+    "typingMultiple": "{name} and {count} others are typing...",
     "image": "Image",
     "location": "Location",
     "file": "File"
@@ -21,7 +21,7 @@
     "name": "Group Name",
     "description": "Group Description",
     "members": "Members",
-    "memberCount": "{{count}} members",
+    "memberCount": "{count} members",
     "admin": "Admin",
     "leave": "Leave Group",
     "delete": "Delete Group",
@@ -33,9 +33,9 @@
   },
   "notification": {
     "newMessage": "New Message",
-    "mentioned": "{{name}} mentioned you",
-    "joined": "{{name}} joined the group",
-    "left": "{{name}} left the group"
+    "mentioned": "{name} mentioned you",
+    "joined": "{name} joined the group",
+    "left": "{name} left the group"
   },
   "empty": {
     "groups": "No groups joined yet",

--- a/travelmate-web/src/locales/en/errors.json
+++ b/travelmate-web/src/locales/en/errors.json
@@ -38,7 +38,7 @@
     "messageSendFailed": "Failed to send message."
   },
   "upload": {
-    "fileTooLarge": "File is too large. (Max {{size}}MB)",
+    "fileTooLarge": "File is too large. (Max {size}MB)",
     "invalidFileType": "Unsupported file type.",
     "uploadFailed": "File upload failed."
   },

--- a/travelmate-web/src/locales/en/itinerary.json
+++ b/travelmate-web/src/locales/en/itinerary.json
@@ -30,12 +30,12 @@
     "PUBLIC": "Public"
   },
   "detail": {
-    "duration": "{{nights}} nights {{days}} days",
+    "duration": "{nights} nights {days} days",
     "dayTrip": "Day Trip",
-    "day": "Day {{number}}",
-    "views": "{{count}} views",
-    "likes": "{{count}} likes",
-    "copies": "{{count}} copies",
+    "day": "Day {number}",
+    "views": "{count} views",
+    "likes": "{count} likes",
+    "copies": "{count} copies",
     "owner": "Owner",
     "collaborators": "Collaborators",
     "shareCode": "Share Code",

--- a/travelmate-web/src/locales/en/nft.json
+++ b/travelmate-web/src/locales/en/nft.json
@@ -10,14 +10,14 @@
   "collect": {
     "title": "Collect NFT",
     "nearby": "Nearby Collection Spots",
-    "distance": "{{distance}}m away",
+    "distance": "{distance}m away",
     "collect": "Collect",
     "collecting": "Collecting...",
     "collected": "Collected!",
     "alreadyCollected": "Already Collected",
     "tooFar": "Please move closer",
     "requirements": "Collection Requirements",
-    "withinRange": "Within {{distance}}m",
+    "withinRange": "Within {distance}m",
     "verifyLocation": "Verifying location..."
   },
   "mint": {

--- a/travelmate-web/src/locales/ko/auth.json
+++ b/travelmate-web/src/locales/ko/auth.json
@@ -10,7 +10,7 @@
     "noAccount": "아직 계정이 없으신가요?",
     "signupLink": "회원가입",
     "or": "또는",
-    "continueWith": "{{provider}}로 계속하기",
+    "continueWith": "{provider}로 계속하기",
     "google": "Google",
     "kakao": "카카오",
     "naver": "네이버"

--- a/travelmate-web/src/locales/ko/chat.json
+++ b/travelmate-web/src/locales/ko/chat.json
@@ -11,8 +11,8 @@
     "sent": "전송됨",
     "delivered": "전달됨",
     "read": "읽음",
-    "typing": "{{name}}님이 입력 중...",
-    "typingMultiple": "{{name}} 외 {{count}}명이 입력 중...",
+    "typing": "{name}님이 입력 중...",
+    "typingMultiple": "{name} 외 {count}명이 입력 중...",
     "image": "이미지",
     "location": "위치",
     "file": "파일"
@@ -33,9 +33,9 @@
   },
   "notification": {
     "newMessage": "새 메시지",
-    "mentioned": "{{name}}님이 회원님을 언급했습니다",
-    "joined": "{{name}}님이 그룹에 참여했습니다",
-    "left": "{{name}}님이 그룹을 나갔습니다"
+    "mentioned": "{name}님이 회원님을 언급했습니다",
+    "joined": "{name}님이 그룹에 참여했습니다",
+    "left": "{name}님이 그룹을 나갔습니다"
   },
   "empty": {
     "groups": "참여 중인 그룹이 없습니다",

--- a/travelmate-web/src/locales/ko/errors.json
+++ b/travelmate-web/src/locales/ko/errors.json
@@ -38,7 +38,7 @@
     "messageSendFailed": "메시지 전송에 실패했습니다."
   },
   "upload": {
-    "fileTooLarge": "파일 크기가 너무 큽니다. (최대 {{size}}MB)",
+    "fileTooLarge": "파일 크기가 너무 큽니다. (최대 {size}MB)",
     "invalidFileType": "지원하지 않는 파일 형식입니다.",
     "uploadFailed": "파일 업로드에 실패했습니다."
   },

--- a/travelmate-web/src/locales/ko/itinerary.json
+++ b/travelmate-web/src/locales/ko/itinerary.json
@@ -30,12 +30,12 @@
     "PUBLIC": "전체 공개"
   },
   "detail": {
-    "duration": "{{nights}}박 {{days}}일",
+    "duration": "{nights}박 {days}일",
     "dayTrip": "당일치기",
-    "day": "Day {{number}}",
-    "views": "조회 {{count}}회",
-    "likes": "좋아요 {{count}}개",
-    "copies": "복사 {{count}}회",
+    "day": "Day {number}",
+    "views": "조회 {count}회",
+    "likes": "좋아요 {count}개",
+    "copies": "복사 {count}회",
     "owner": "작성자",
     "collaborators": "협업자",
     "shareCode": "공유 코드",

--- a/travelmate-web/src/locales/ko/nft.json
+++ b/travelmate-web/src/locales/ko/nft.json
@@ -10,14 +10,14 @@
   "collect": {
     "title": "NFT 수집",
     "nearby": "주변 수집 장소",
-    "distance": "{{distance}}m 거리",
+    "distance": "{distance}m 거리",
     "collect": "수집하기",
     "collecting": "수집 중...",
     "collected": "수집 완료!",
     "alreadyCollected": "이미 수집함",
     "tooFar": "더 가까이 이동해주세요",
     "requirements": "수집 조건",
-    "withinRange": "{{distance}}m 이내",
+    "withinRange": "{distance}m 이내",
     "verifyLocation": "위치 확인 중..."
   },
   "mint": {

--- a/travelmate-web/src/services/authService.test.ts
+++ b/travelmate-web/src/services/authService.test.ts
@@ -41,7 +41,8 @@ describe('AuthService', () => {
 
       expect(result.accessToken).toBe('test-access-token');
       expect(result.user.email).toBe('test@example.com');
-      expect(localStorage.getItem('accessToken')).toBe('test-access-token');
+      // Tokens stored in memory (security), not localStorage
+      expect(authService.getToken()).toBe('test-access-token');
     });
 
     it('should throw error on invalid credentials', async () => {
@@ -150,8 +151,18 @@ describe('AuthService', () => {
 
   describe('logout', () => {
     it('should clear tokens on logout', async () => {
-      localStorage.setItem('accessToken', 'test-token');
-      localStorage.setItem('tokenExpiresAt', '9999999999999');
+      // Login first to set in-memory tokens
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          accessToken: 'test-token',
+          refreshToken: 'test-refresh',
+          expiresIn: 3600,
+          tokenType: 'Bearer',
+          user: { id: 1, email: 'test@example.com', nickname: 'test' },
+        }),
+      } as Response);
+      await authService.login({ email: 'test@example.com', password: 'pass' });
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -160,10 +171,10 @@ describe('AuthService', () => {
 
       await authService.logout();
 
-      // accessToken과 tokenExpiresAt은 localStorage에서 제거됨
-      // refreshToken은 httpOnly 쿠키로 서버에서 처리하므로 localStorage에서 제거하지 않음
+      // In-memory tokens should be cleared
+      expect(authService.getToken()).toBeNull();
+      // Legacy localStorage cleanup also runs
       expect(localStorage.getItem('accessToken')).toBeNull();
-      expect(localStorage.getItem('tokenExpiresAt')).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- **Backend**: Remove okhttp3 exclusion from web3j (BlockchainConfig.java needs OkHttpClient via HttpService)
- **Frontend i18n**: Normalize all locale template variables from `{{var}}` to `{var}` across en/ko locales to match the interpolation regex `/{(\w+)}/g`
- **Frontend authService test**: Fix assertion to use `authService.getToken()` instead of `localStorage.getItem('accessToken')` (tokens stored in memory for XSS security)

## Test plan
- [ ] Backend CI: `mvn clean package` compiles without okhttp3 errors
- [ ] Frontend CI: i18n interpolation test passes (`"5 members"` not `"{5} members"`)
- [ ] Frontend CI: authService login test passes (in-memory token check)


Generated with [Claude Code](https://claude.com/claude-code)