### PR TITLE
fix: allow bean definition overriding in test profile

### DIFF
--- a/travelmate-backend/src/test/resources/application.yml
+++ b/travelmate-backend/src/test/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration


### PR DESCRIPTION
## Summary
Spring Boot 3.4.3 relocated JacksonAutoConfiguration to a new package but both old and new versions are on the classpath, causing `BeanDefinitionOverrideException` for `jsonComponentModule` bean in controller tests.

Fix: Add `spring.main.allow-bean-definition-overriding: true` in test application.yml.

## Test plan
- [ ] Backend CI: All controller tests pass (no ApplicationContext failure)


Generated with [Claude Code](https://claude.com/claude-code)