### PR TITLE
infra: fix 6 critical issues in k8s, monitoring, docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
     volumes:
       - redis_data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -41,11 +41,11 @@ spec:
                 name: travelmate-secrets
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "100m"
-            limits:
               memory: "512Mi"
-              cpu: "500m"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
           livenessProbe:
             httpGet:
               path: /api/actuator/health/liveness
@@ -125,3 +125,16 @@ spec:
         target:
           type: Utilization
           averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300  # 5분 안정화 윈도우 (flapping 방지)
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: travelmate-ingress
   namespace: travelmate
   annotations:
-    kubernetes.io/ingress.class: nginx
+    # kubernetes.io/ingress.class is deprecated since K8s 1.18; use spec.ingressClassName instead
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "10m"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
@@ -16,6 +16,7 @@ metadata:
       add_header X-Content-Type-Options "nosniff" always;
       add_header X-XSS-Protection "1; mode=block" always;
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
         - travelmate.app
@@ -50,7 +51,7 @@ metadata:
   name: travelmate-ws-ingress
   namespace: travelmate
   annotations:
-    kubernetes.io/ingress.class: nginx
+    # kubernetes.io/ingress.class is deprecated since K8s 1.18; use spec.ingressClassName instead
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
@@ -60,6 +61,7 @@ metadata:
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
         - api.travelmate.app

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - backend-deployment.yaml
   - frontend-deployment.yaml
   - ingress.yaml
+  - pdb.yaml
 
 commonLabels:
   app.kubernetes.io/name: travelmate

--- a/k8s/pdb.yaml
+++ b/k8s/pdb.yaml
@@ -1,0 +1,22 @@
+# PodDisruptionBudget — 노드 드레인/업그레이드 중 최소 가용성 보장
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: travelmate-backend-pdb
+  namespace: travelmate
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: travelmate-backend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: travelmate-frontend-pdb
+  namespace: travelmate
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: travelmate-frontend

--- a/k8s/postgres-deployment.yaml
+++ b/k8s/postgres-deployment.yaml
@@ -50,11 +50,9 @@ spec:
           livenessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - travelmate_user
-                - -d
-                - travelmate
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d travelmate
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
@@ -62,11 +60,9 @@ spec:
           readinessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - travelmate_user
-                - -d
-                - travelmate
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d travelmate
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3

--- a/k8s/redis-deployment.yaml
+++ b/k8s/redis-deployment.yaml
@@ -30,6 +30,14 @@ spec:
             - "256mb"
             - --maxmemory-policy
             - "allkeys-lru"
+            - --requirepass
+            - $(REDIS_PASSWORD)
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: travelmate-secrets
+                  key: REDIS_PASSWORD
           ports:
             - containerPort: 6379
               name: redis
@@ -43,8 +51,9 @@ spec:
           livenessProbe:
             exec:
               command:
-                - redis-cli
-                - ping
+                - sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" ping
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -52,8 +61,9 @@ spec:
           readinessProbe:
             exec:
               command:
-                - redis-cli
-                - ping
+                - sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" ping
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -26,8 +26,9 @@ scrape_configs:
     metrics_path: /metrics
 
   # Backend API metrics (Spring Boot Actuator)
+  # /api context path prefix required — annotation in backend-deployment.yaml uses /api/actuator/prometheus
   - job_name: 'travelmate-backend'
-    metrics_path: /actuator/prometheus
+    metrics_path: /api/actuator/prometheus
     static_configs:
       - targets: ['backend:8080']
     relabel_configs:
@@ -49,11 +50,6 @@ scrape_configs:
   - job_name: 'redis-exporter'
     static_configs:
       - targets: ['redis-exporter:9121']
-
-  # Nginx Exporter
-  - job_name: 'nginx-exporter'
-    static_configs:
-      - targets: ['nginx-exporter:9113']
 
   # cAdvisor (Container metrics)
   - job_name: 'cadvisor'


### PR DESCRIPTION
## Summary

자동화된 인프라 점검에서 발견된 보안·신뢰성 이슈 6건 수정.

### 보안 (Critical)

- **k8s Redis 비밀번호 없음**: redis-deployment.yaml에서 --requirepass 미설정. K8s 클러스터 내 Redis가 인증 없이 접근 가능했음. Secret에서 REDIS_PASSWORD 주입하도록 수정.
- **Redis probe 인증 누락**: redis-cli ping에 -a 플래그 없어 requirepass 설정 시 probe가 NOAUTH 오류로 실패. redis-cli -a $REDIS_PASSWORD ping으로 수정.
- **dev docker-compose Redis healthcheck 동일 문제 수정**

### 정확성 (Bug)

- **Prometheus metrics path 불일치**: prometheus.yml에서 /actuator/prometheus 사용했으나 backend context-path가 /api이므로 실제 엔드포인트는 /api/actuator/prometheus. 스크레이핑이 404로 실패.
- **Prometheus nginx-exporter job**: docker-compose.monitoring.yml에 nginx-exporter 서비스가 없는데 scrape job이 등록되어 오류 발생. 삭제.
- **Postgres probe 유저명 하드코딩**: pg_isready -U travelmate_user 고정 → POSTGRES_USER env var 사용으로 수정.
- **Ingress deprecated annotation**: kubernetes.io/ingress.class annotation → spec.ingressClassName (K8s 1.18+ 방식)

### 신뢰성 (Improvement)

- **Backend 리소스 상향**: Spring Boot에 512Mi/500m은 부족. 1Gi/1000m으로 조정.
- **HPA scaleDown behavior 추가**: 안정화 윈도우 5분 + 분당 최대 1 pod 감소 (flapping 방지).
- **PodDisruptionBudget 추가** (k8s/pdb.yaml): backend/frontend minAvailable: 1. 노드 드레인 시 서비스 연속성 보장.

## Test plan

- [ ] kubectl apply -k k8s/ 에러 없이 적용 확인
- [ ] Redis pod liveness/readiness probe 정상 통과 확인
- [ ] Prometheus targets 페이지에서 travelmate-backend job UP 확인
- [ ] kubectl get pdb -n travelmate PDB 생성 확인
- [ ] HPA behavior 설정 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Updated Kubernetes deployments with increased resource limits and new HPA scaling policies with stabilization windows
  * Added Pod Disruption Budget for improved application availability during cluster maintenance
  * Replaced deprecated ingress annotation with standard ingressClassName field

* **Security**
  * Enhanced Redis and database authentication in health check configurations
  * Updated health probes to use environment-based credentials

* **Monitoring**
  * Updated Prometheus metrics endpoint configuration
  * Removed Nginx Exporter scrape job

<!-- end of auto-generated comment: release notes by coderabbit.ai -->