### PR TITLE
refactor: consolidate MatchingService into CompanionMatchingService

### DIFF
--- a/travelmate-backend/src/main/java/com/travelmate/service/CompanionMatchingService.java
+++ b/travelmate-backend/src/main/java/com/travelmate/service/CompanionMatchingService.java
@@ -11,6 +11,7 @@ import com.travelmate.entity.User.BudgetPreference;
 import com.travelmate.exception.BusinessException;
 import com.travelmate.repository.MatchRequestRepository;
 import com.travelmate.repository.TravelItineraryRepository;
+import com.travelmate.repository.UserBlockRepository;
 import com.travelmate.repository.UserRepository;
 import com.travelmate.util.TravelStyleMatcher;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,7 @@ public class CompanionMatchingService {
     private final MatchRequestRepository matchRequestRepository;
     private final TravelItineraryRepository travelItineraryRepository;
     private final NotificationService notificationService;
+    private final UserBlockRepository userBlockRepository;
 
     // ===== 추천 =====
 
@@ -85,6 +87,11 @@ public class CompanionMatchingService {
 
         if (!Boolean.TRUE.equals(requester.getIsMatchingEnabled())) {
             throw BusinessException.matchingNotEnabled();
+        }
+
+        // 차단 관계 확인 (양방향)
+        if (userBlockRepository.isBlockedEitherWay(requesterId, request.getReceiverId())) {
+            throw BusinessException.forbidden("차단 관계인 사용자에게는 매칭 요청을 보낼 수 없습니다.");
         }
 
         matchRequestRepository.findActiveRequestBetween(requesterId, request.getReceiverId())
@@ -366,6 +373,12 @@ public class CompanionMatchingService {
     // ===== 후보 조회 =====
 
     private List<User> getCandidates(User currentUser, List<Long> excludeIds) {
+        // 차단 관계 사용자 추가 제외
+        List<Long> blockedByMe = userBlockRepository.findBlockedUserIds(currentUser.getId());
+        List<Long> blockedMe = userBlockRepository.findBlockerUserIds(currentUser.getId());
+        excludeIds.addAll(blockedByMe);
+        excludeIds.addAll(blockedMe);
+
         if (Boolean.TRUE.equals(currentUser.getIsLocationEnabled())
                 && currentUser.getCurrentLatitude() != null
                 && currentUser.getCurrentLongitude() != null) {


### PR DESCRIPTION
레거시 MatchingService를 CompanionMatchingService로 통합

- sendMatchRequest()에 양방향 차단 관계 검사 추가 (userBlockRepository.isBlockedEitherWay)
- getCandidates()에서 차단 사용자 제외 로직 이식
- MatchingController는 이미 CompanionMatchingService만 참조 (변경 불필요)
- +13 lines only

Test plan:
- 매칭 요청 시 차단된 사용자에게 요청 불가 확인
- 추천 후보 목록에 차단 사용자 미포함 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Strengthened user blocking: blocked users can no longer send or receive match requests with each other through improved bidirectional blocking enforcement.
  * Blocked user filtering: users who have blocked you or whom you have blocked are now automatically excluded from candidate recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->