### PR TITLE
feat: Sprint P0-1+P0-2 - 동반자 매칭 호환성 점수 서비스 및 top20 추천 API

### DIFF
--- a/travelmate-backend/src/main/java/com/travelmate/controller/MatchingController.java
+++ b/travelmate-backend/src/main/java/com/travelmate/controller/MatchingController.java
@@ -24,7 +24,7 @@ public class MatchingController {
     @GetMapping("/recommendations")
     public ResponseEntity<List<MatchRecommendation>> getRecommendations(
             @AuthenticationPrincipal String userId,
-            @RequestParam(defaultValue = "10") int limit) {
+            @RequestParam(defaultValue = "20") int limit) {
         List<MatchRecommendation> recommendations = matchingService
                 .getMatchRecommendations(Long.parseLong(userId), limit);
         return ResponseEntity.ok(recommendations);
@@ -46,6 +46,24 @@ public class MatchingController {
             @Valid @RequestBody RespondMatchRequest request) {
         MatchRequestResponse response = matchingService
                 .respondToMatchRequest(Long.parseLong(userId), id, request.getAccept());
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/requests/{id}/accept")
+    public ResponseEntity<MatchRequestResponse> acceptRequest(
+            @AuthenticationPrincipal String userId,
+            @PathVariable Long id) {
+        MatchRequestResponse response = matchingService
+                .respondToMatchRequest(Long.parseLong(userId), id, true);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/requests/{id}/reject")
+    public ResponseEntity<MatchRequestResponse> rejectRequest(
+            @AuthenticationPrincipal String userId,
+            @PathVariable Long id) {
+        MatchRequestResponse response = matchingService
+                .respondToMatchRequest(Long.parseLong(userId), id, false);
         return ResponseEntity.ok(response);
     }
 


### PR DESCRIPTION
## Sprint P0-1 + P0-2

### P0-1: 호환성 점수 계산 서비스 검증 (CompatibilityScoreService)
기존 구현이 정확하게 완료되어 있음을 확인:
- 여행스타일 일치도: **30%** (TravelStyleMatcher 기반)
- 일정 겹침도: **25%** (최대 겹침 일수 × 2.5, 최대 25점)
- 예산 유사도: **20%** (BudgetPreference ordinal 거리 기반 switch)
- 언어 공통성: **15%** (Jaccard similarity 기반, 최소 3점 보장)
- 사용자 평점: **10%** (rating × 8/5 + reviewBonus, 최대 10점)

### P0-2: API 엔드포인트 변경 및 추가
- `GET /api/matching/recommendations`: 기본 limit **10 → 20** 변경
- `POST /api/matching/requests`: 기존 구현 확인 ✅
- `PUT /api/matching/requests/{id}/accept`: **신규 추가** (기존 /respond를 accept=true로 호출)
- `PUT /api/matching/requests/{id}/reject`: **신규 추가** (기존 /respond를 accept=false로 호출)
- `GET /api/matching/history`: 기존 구현 확인 ✅

> 기존 `PUT /requests/{id}/respond` 엔드포인트는 하위 호환성 유지를 위해 보존

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to accept or reject match requests
  * Increased default number of recommendations from 10 to 20

<!-- end of auto-generated comment: release notes by coderabbit.ai -->