### PR TITLE
fix: auto-fix CI errors

### DIFF
--- a/travelmate-web/src/types/css.d.ts
+++ b/travelmate-web/src/types/css.d.ts
@@ -1,0 +1,6 @@
+// CSS module type declarations
+// Fixes TS2882: Cannot find module or type declarations for side-effect import of '*.css'
+declare module '*.css' {
+  const styles: { [className: string]: string };
+  export default styles;
+}


### PR DESCRIPTION
자동 CI 수정

## 수정 내용
- TypeScript TS2882 에러 수정: CSS 모듈 타입 선언 추가
- 파일: `travelmate-web/src/types/css.d.ts`

## 원인
`*.css` 사이드이펙트 임포트에 대한 타입 선언이 없어 TypeScript strict 모드에서 TS2882 에러 발생

## 영향 파일
src/App.tsx, src/components/*.tsx 등 20개 파일의 CSS import 에러 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript configuration for CSS module support to enhance development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->